### PR TITLE
fix: resolve hero text and card overlap on mobile (320px)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ function App() {
       ) : (
         <>
           <Header />
-          <main>
+          <main >
             <HeroSection />
             <FeaturesGrid />
             <TestimonialsCarousel />

--- a/src/components/home/HeroSection.jsx
+++ b/src/components/home/HeroSection.jsx
@@ -84,7 +84,7 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 pt-23 lg:pt-0">
       {/* Animated Background Elements */}
       <div className="absolute inset-0">
         {/* Large gradient orbs */}


### PR DESCRIPTION
# 🚀 Pull Request for CLUSTER Portal

### 📝 Title  
Mobile View (320px): Hero Text and Cards Overlap

---

### 🎯 Enhancement Objective: Mobile Responsiveness  
Improve mobile UX by eliminating component overlap in the CLUSTER section.

---

### 🎯 Goals  
- Ensure all content is visible and accessible on mobile devices  
- Maintain design consistency across all viewports  
- Comply with accessibility standards for touch targets and readability  

---

### 👤 Your Information  
**Full Name:** Yash Chauhan  
**GitHub Username:** [YashChauhan-2303](https://github.com/YashChauhan-2303)  
**Email Address:** yashchauhan.2303@gmail.com  
**Role:** SSOC Contributor  

---

### 🔗 Related Issue  
Closes #13  

---

### 🛠️ Proposed Changes  

#### Scope of Work  
- Adjusted top padding using `pt-23 lg:pt-0` in the Hero section  
- Ensured consistent spacing across mobile and desktop breakpoints  
- Fixed overlapping issue by adding vertical space on smaller screens  

---

### 📷 Screenshots  

![image](https://github.com/user-attachments/assets/589c4885-e394-4054-b382-185ed118c33b)  
![image](https://github.com/user-attachments/assets/83464b53-25a4-40a3-981f-6f7881ea323f)  

---

### ✅ Confirmation Checklist  
- [x] I have read the contribution guidelines  
- [x] I have linked my latest merged PR (if applicable)  
