### PR TITLE
fix: correct Home link in navbar to navigate to homepage

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -17,7 +17,7 @@ const Header = () => {
     }, []);
 
     const navItems = [
-        { name: 'Home', href: '#', hasDropdown: false },
+        { name: 'Home', href: '/', hasDropdown: false },
         { name: 'Community', href: '#', hasDropdown: false },
         { name: 'Research', href: '/research', hasDropdown: false },
         { name: 'About', href: '#', hasDropdown: false },


### PR DESCRIPTION
# 🐛 Fix: "Home" Link in Navbar Not Navigating to Homepage

## 🔗 Related Issue
Closes #51

## 📋 Summary
This PR fixes a navigation bug where clicking the "Home" link in the navbar did not redirect to the homepage (`/`). This ensures consistent and expected behavior across all routes.

## ✅ Changes Made
- Updated the `href` of the "Home" nav item from `"#"` to `"/"` in `Header.jsx`
- Verified that the `Link` component from `react-router-dom` handles navigation correctly

## 🧪 How to Test
1. Navigate to any route (e.g., `/research`, `/contact`)
2. Click the "Home" link in the navbar
3. You should be redirected to the homepage (`/`)

## 🧼 Checklist
- [x] Navigation to homepage works from all other routes
- [x] Mobile and desktop nav both reflect the fix
- [x] Code follows existing style and conventions

---

### Your Full Name  
*Bishal Saha*

---

### GitHub Username  
*@bishal7448*

---

### Email Address  
*saha.bishal7676@gmail.com*

---

### Your Role  
*SSOC Contributor.*

---

https://github.com/user-attachments/assets/35bec13e-1465-4e8b-a32a-28d7e323c4ea
