### PR TITLE
Add margin at top  of 2.5 rem to header of research page

### DIFF
--- a/src/components/Research.css
+++ b/src/components/Research.css
@@ -15,7 +15,7 @@
 .research-header {
   width: 100%;
   text-align: center;
-  margin-bottom: 2.5rem;
+  margin: 2.5rem  0;
 }
 
 .research-header h1 {


### PR DESCRIPTION
# 🚀 Pull Request for CLUSTER Portal

### Related Issue Title  
*Enter the title of the issue your PR addresses.*  
Insufficient Spacing Between Navbar and Page Heading #123
_

---

### Project Goal  
*Describe the aim or objective of the issue or feature.*  
_There was insufficient space between the navbar and page heading I have added a margin top of 2.5 rem in order to make it
look better

---

### Your Full Name  
*Enter your full name.*
Sara

---

### GitHub Username  
*Your GitHub handle.*
sara-1129
---

### Email Address  
*Your email for communication.*
sarasaini3116@gmail.com

---

### Your Role  
*E.g., GSSOC, SSOC, JWOC, Contributor.*
Contributer

---

### Issue Number (if any)  
*The issue number this PR closes.*  
_E.g., Closes #45_
 #123

---

### Describe Your Changes  
*Explain what you added or modified in this PR.*  
_Fixed the user login bug by updating the auth flow._
_There was insufficient space between the navbar and page heading I have added a margin top of 2.5 rem in order to make it
look better

---

### Type of Change  
*Select one or more:*  
- [ ] Bug fix (non-breaking change)  
- [ ] New feature (non-breaking change)  
- [ x] Code style / formatting  
- [ ] Breaking change (may cause backward incompatibility)  
- [ ] Documentation update  

---

### Testing Details  
*Describe how you tested your changes.*  
_Ran unit tests locally and verified login functionality._

---

### Checklist  
*Please check all that apply:*  
- [ x] I have followed the project's contributing guidelines.  
- [ x] I have self-reviewed my code.  
- [x ] I have added comments where necessary.  
- [ ] I have updated documentation if needed.  
- [ x] My changes do not generate new warnings.  
- [ ] I have added tests or screenshots proving my fix/feature works.  
- [ ] All dependent changes have been merged.  
